### PR TITLE
compliance to ecdsa spec

### DIFF
--- a/contracts/EllipticCurve.sol
+++ b/contracts/EllipticCurve.sol
@@ -379,7 +379,7 @@ contract EllipticCurve {
         C = 1;
 
         // To disambiguate between public key solutions, include comment below.
-        if(rs[0] == 0 || rs[0] >= n || rs[1] == 0) {// || rs[1] > lowSmax)
+        if(rs[0] == 0 || rs[0] >= n || rs[1] == 0 ||rs[1]>=n) {// || rs[1] > lowSmax)
             console.log("ici");
             return false;
         }

--- a/contracts/OptimizedCurve.sol
+++ b/contracts/OptimizedCurve.sol
@@ -366,7 +366,7 @@ library OptimizedCurve {
         returns (bool)
     {
         // To disambiguate between public key solutions, include comment below.
-        if(rs[0] == 0 || rs[0] >= n || rs[1] == 0) {// || rs[1] > lowSmax)
+        if(rs[0] == 0 || rs[0] >= n || rs[1] == 0 ||rs[1] >=n) {// || rs[1] > lowSmax)
             return false;
         }
 


### PR DESCRIPTION
As part of ecdsa, s shall be lesser than n.
The mistake here comes from removing malleability enforcing s<n/2 like in bitcoin to avoid Mtgox flaw (requiring SUF, strong unforgeability)